### PR TITLE
feat: Add pre-commit hook setup instructions to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ surrealdb-go-starter-project
 .idea
 
 bin/
+
+venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+# .pre-commit-config.yaml
+repos:
+  - repo: local
+    hooks:
+      - id: go-test
+        name: Run Go Tests
+        entry: go test ./...
+        language: golang
+        types: [go]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+# .pre-commit-hooks.yaml
+- id: go-test
+  name: Run Go Tests
+  entry: go test -v ./...
+  language: golang
+  types: [go]

--- a/README.md
+++ b/README.md
@@ -73,6 +73,37 @@ You are encouraged to open pull requests or issues, and I'll review them as soon
 
 Happy coding with SurrealDB for Go!
 
+
+## Pre-commit Hook Setup
+
+To ensure code quality and that all tests pass before committing, we use pre-commit hooks.
+
+### Install pre-commit
+
+First, install pre-commit using pip:
+
+```bash
+pip install pre-commit
+```
+
+### Install pre-commit hooks
+
+Run the following command to install the pre-commit hook:
+
+```bash
+pre-commit install
+```
+
+
+### Running pre-commit manually
+
+You can run pre-commit manually on all files with:
+
+```bash
+pre-commit run --all-files
+```
+
+
 ## Project Roadmap
 
 TODO: Move to Epic / Wiki soon


### PR DESCRIPTION
- Added a new section in the README.md to guide users on setting up pre-commit hooks.
- Instructions include installing pre-commit using pip, installing the pre-commit hooks, and running pre-commit manually.
- Updated .gitignore to include `venv/` for virtual environment directories.

This ensures code quality and that all tests pass before committing code to the repository.